### PR TITLE
🐛 fix: Update conventional commit format to add space after emoji

### DIFF
--- a/extensions/conventional-comments/src/utils/formatDescription.ts
+++ b/extensions/conventional-comments/src/utils/formatDescription.ts
@@ -1,5 +1,4 @@
 import { FormValue } from "@raycast/api";
-
 import gitmoji from "../data/gitmoji";
 
 interface Props {
@@ -11,13 +10,13 @@ interface Props {
 const formatDescription = ({ format, type: _type, values }: Props) => {
   const type = gitmoji?.types[_type];
 
-  const hasEmoji = format.toString().includes("emoji");
+  const hasType = format.toString().includes("type");
   const scope = values?.ccScope;
 
   const description = format
     .toString()
-    .replace(/\{emoji\}/g, type?.emoji)
-    .replace(/\{scope\}/g, values?.ccScope ? (hasEmoji ? ` (${scope})` : `(${scope})`) : "")
+    .replace(/\{emoji\}/g, scope || hasType ? `${type?.emoji} ` : `${type?.emoji}`)
+    .replace(/\{scope\}/g, scope ? `(${scope})` : "")
     .replace(/\{description\}/g, values?.ccDescription ? values?.ccDescription.toString() : "")
     .replace(/\{type\}/g, type?.commit);
 


### PR DESCRIPTION
## Description

Update conventional commit format to add space after emoji

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
